### PR TITLE
SFR-877 Fix Identifier Issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 This file documents all updates and releases to the ResearchNow Data Ingest pipeline.
 
 ## [Unreleased]
+### Fixed
+- Improved identifier parsing for MET catalog
 
 ## [0.0.3] - 2020-04-01
 ### Added

--- a/lambda/sfr-publisher-reader/lib/models/metRecord.py
+++ b/lambda/sfr-publisher-reader/lib/models/metRecord.py
@@ -87,7 +87,7 @@ class MetItem(object):
         # These will be used later
         try:
             self.downloadURI = self.data['downloadParentUri'].replace('/digital', '')
-        except KeyError:
+        except (KeyError, AttributeError):
             self.downloadURI = self.data['downloadUri']
         self.coverURI = self.data['imageUri']
         self.viewURI = self.ITEM_UI.format(self.itemID)
@@ -128,6 +128,13 @@ class MetItem(object):
         """
         logger.info('Extracting identifiers')
         for rec in [self.work, self.instance, self.item]:
+            # Append main id from API response
+            logger.debug('Adding identifier {}({}) to {}'.format(
+                self.itemID, 'generic', rec
+            ))
+            rec.identifiers.append(
+                type=None, identifier='met.{}'.format(self.itemID), weight=1
+            )
             # Extracts identifier fields by prefix
             ids = list(filter(lambda x: x[:11] == 'identifier.', rec.keys()))
 

--- a/lambda/sfr-publisher-reader/lib/models/metRecord.py
+++ b/lambda/sfr-publisher-reader/lib/models/metRecord.py
@@ -133,7 +133,11 @@ class MetItem(object):
                 self.itemID, 'generic', rec
             ))
             rec.identifiers.append(
-                type=None, identifier='met.{}'.format(self.itemID), weight=1
+                Identifier(
+                    type=None,
+                    identifier='met.{}'.format(self.itemID),
+                    weight=1
+                )
             )
             # Extracts identifier fields by prefix
             ids = list(filter(lambda x: x[:11] == 'identifier.', rec.keys()))

--- a/lambda/sfr-publisher-reader/lib/readers/metReader.py
+++ b/lambda/sfr-publisher-reader/lib/readers/metReader.py
@@ -31,20 +31,19 @@ class MetReader(AbsSourceReader):
     
     def scrapeResourcePages(self):
         for itemID in self.itemIDs:
-            logger.info('Fetching metadata for record'.format(itemID))
+            logger.info('Fetching metadata for record {}'.format(itemID))
             pageResp = requests.get(self.ITEM_API.format(itemID))
             pageData = pageResp.json()
 
             self.works.append(self.scrapeRecordMetadata(itemID, pageData))
 
     def scrapeRecordMetadata(self, itemID, pageData):
-        logger.debug('Extracting data from record')
+        logger.debug('Extracting data from record {}'.format(itemID))
 
         # Create local MET record to hold intermediate data
-        try:
-            itemID = pageData['parentId']
-        except KeyError:
-            pass
+        parentID = pageData['parentId']
+        if parentID != -1:
+            itemID = parentID
         newItem = MetItem(itemID, pageData)
 
         # Extract data from MET API format

--- a/lambda/sfr-publisher-reader/tests/test_metItem.py
+++ b/lambda/sfr-publisher-reader/tests/test_metItem.py
@@ -81,17 +81,18 @@ class TestMETItem:
         assert testItem.item.provider == 'testSource'
 
     def test_parseIdentifiers(self, testItem):
+        testItem.itemID = 123
         testItem.work['identifier.test'] = 1
         testItem.instance['identifier.generic'] = 2
         testItem.item['identifier.test'] = 3
 
         testItem.parseIdentifiers()
-        assert len(testItem.work.identifiers) == 1
-        assert len(testItem.instance.identifiers) == 1
-        assert len(testItem.item.identifiers) == 1
-        assert testItem.work.primary_identifier.identifier == 1
-        assert testItem.work.primary_identifier.type == 'test' 
-        assert testItem.instance.identifiers[0].identifier == 'met.2'
+        assert len(testItem.work.identifiers) == 2
+        assert len(testItem.instance.identifiers) == 2
+        assert len(testItem.item.identifiers) == 2
+        assert testItem.work.primary_identifier.identifier == 'met.123'
+        assert testItem.work.primary_identifier.type == None
+        assert testItem.instance.identifiers[0].identifier == 'met.123'
     
     def test_parseSubjects(self, testItem):
         testItem.work.subjects = 'testSubj1 ; testSubj2 ; testSubj3'

--- a/lambda/sfr-publisher-reader/tests/test_metReader.py
+++ b/lambda/sfr-publisher-reader/tests/test_metReader.py
@@ -41,7 +41,7 @@ class TestMETReader:
     @patch.object(MetReader, 'transformMetadata', return_value='testWork')
     @patch.object(MetItem, 'extractRelevantData')
     def test_scrapeRecordMetadata(self, mockTransform, mockExtract, testReader):
-        newItem = testReader.scrapeRecordMetadata(1, {})
+        newItem = testReader.scrapeRecordMetadata(1, {'parentId': 1})
         mockExtract.assert_called_once()
         mockTransform.assert_called_once()
         assert newItem == 'testWork'


### PR DESCRIPTION
The parent identifiers were not being properly detected or set in all cases and this ensures that the true identifiers are assigned.