### PR TITLE
HOTFIX Resolve NONE identifier bug in OCLC Lookup

### DIFF
--- a/lambda/sfr-oclc-lookup/lib/parsers/parse856Holding.py
+++ b/lambda/sfr-oclc-lookup/lib/parsers/parse856Holding.py
@@ -42,7 +42,7 @@ class HoldingParser:
         except IndexError:
             raise HoldingError('856 Field is missing u subfield for URI')
         
-        self.identifier = self.loadURIid()
+        self.loadURIid()
     
     def loadURIid(self):
         """Regex to extract identifier from an URI. \/((?:(?!\/)[^.])+ matches
@@ -71,12 +71,23 @@ class HoldingParser:
         for source, regex in self.EBOOK_REGEX.items():
             self.source = source
             if re.search(regex, self.uri):
+
+                # Check if link is accessible (e.g. public domain/open source)
                 if source == 'internetarchive':
                     if self.checkIAStatus() is True:
                         return None
+                    linkID = Identifier(
+                        identifier='ia.{}'.format(self.identifier),
+                        source='generic'
+                    )
                 elif source == 'hathitrust':
                     self.parseHathiLink()
                     return None
+                else:
+                    linkID = Identifier(
+                        identifier=self.identifier,
+                        source='gutenberg'
+                    )
 
                 self.instance.addFormat(**{
                     'source': source,
@@ -87,7 +98,7 @@ class HoldingParser:
                             local=False, download=False, images=False, ebook=True
                         )
                     ],
-                    'identifiers': [Identifier(identifier=self.identifier, source='hathi')]
+                    'identifiers': [linkID]
                 })
                 return True
     

--- a/lambda/sfr-oclc-lookup/tests/test_holdingParser.py
+++ b/lambda/sfr-oclc-lookup/tests/test_holdingParser.py
@@ -13,7 +13,7 @@ class TestHoldingParse(unittest.TestCase):
         self.assertEqual(testInst.instance, 'mockInstance')
         self.assertEqual(testInst.source, 'unknown')
     
-    @patch.object(HoldingParser, 'loadURIid', return_value='testID')
+    @patch.object(HoldingParser, 'loadURIid')
     def test_parseField_success(self, mockURILoad):
         mockField = MagicMock()
         mockField.ind1 = '4'
@@ -27,7 +27,6 @@ class TestHoldingParse(unittest.TestCase):
 
         testInst.parseField()
         self.assertEqual(testInst.uri, 'testURI')
-        self.assertEqual(testInst.identifier, 'testID')
         mockURILoad.assert_called_once()
     
     def test_parseField_wrong_ind1(self):


### PR DESCRIPTION
The OCLC Lookup function has a special class for parsing the `856` external link MARC field. However, when it found a non-hathi link it would attempt to assign it a non-existent HathiTrust identifier. This caused these records to not be imported into the database.

This resolves the issue by ensuring that the parsed identifier is present and adding the proper source (even if it is `generic` for InternetArchive identifiers. This should resolve the issue and give us better control over the type of identifiers imported.