### PR TITLE
HOTFIX Fix bug in error handling in date module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file documents all updates and releases to the ResearchNow Data Ingest pipe
 ### Fixed
 - Improved identifier parsing for MET catalog
 - Fix bug in OCLC Catalog lookup to ensure that proper identifiers are fetched from records in the MARC 856 field
+- Bug fix for error catching from the calendar module when parsing YYYY-MM or YYYY-YY date ranges
 
 ## [0.0.3] - 2020-04-01
 ### Added

--- a/core/sfr-db-core/sfrCore/model/date.py
+++ b/core/sfr-db-core/sfrCore/model/date.py
@@ -1,6 +1,7 @@
 import re
 from dateutil.parser import parse
 from datetime import date
+import calendar
 from calendar import monthrange, IllegalMonthError
 from sqlalchemy import (
     Table,
@@ -283,7 +284,7 @@ class DateField(Core, Base):
                         date(year, month, 1),
                         date(year, month, lastDay)
                     )
-                except IllegalMonthError:
+                except (IllegalMonthError, TypeError):
                     logger.debug('Year-month is actually year-2 dig year')
                     secondYear = '{}{}'.format(dateObj[:2], dateObj[5:])
                     self.display_date = '{}/{}'.format(dateObj[:4], secondYear)

--- a/core/sfr-db-core/sfrCore/model/date.py
+++ b/core/sfr-db-core/sfrCore/model/date.py
@@ -1,7 +1,6 @@
 import re
 from dateutil.parser import parse
 from datetime import date
-import calendar
 from calendar import monthrange, IllegalMonthError
 from sqlalchemy import (
     Table,

--- a/core/sfr-db-core/tests/test_dates.py
+++ b/core/sfr-db-core/tests/test_dates.py
@@ -162,6 +162,11 @@ class TestDates(unittest.TestCase):
         testDate.setDateRange('2018-02')
         self.assertEqual(testDate.date_range, '[2018-02-01, 2018-02-28)')
 
+    def test_parse_false_month(self):
+        testDate = DateField()
+        testDate.setDateRange('1916-18')
+        self.assertEqual(testDate.date_range, '[1916-01-01, 1918-12-31)')
+
     def test_parse_bad_date(self):
         testDate = DateField()
         testDate.setDateRange('Modnay, Dec 01, 87')


### PR DESCRIPTION
The date module has a condition for handling ambigious YYYY-MM / YYYY-YY date values. It attempts to resolve them as year-month values but if the month value falls outside of the 1-12 range a special error is thrown. Because of a bug within the module being used to raise this error a secondary TypeError is thrown, which was not caught until a high level and which blocked the import of these records.

This udpate catches this error to ensure that they are properly parsed, including adding a new test case to prevent any regressions in this component.