### PR TITLE
HOTFIX Pub Reader Bugs

### DIFF
--- a/lambda/sfr-cover-writer/dev-requirements.txt
+++ b/lambda/sfr-cover-writer/dev-requirements.txt
@@ -1,5 +1,4 @@
 coverage
 flake8
-Pillow
 pytest
 pytest-mock

--- a/lambda/sfr-cover-writer/requirements.txt
+++ b/lambda/sfr-cover-writer/requirements.txt
@@ -1,4 +1,5 @@
 boto3
+Pillow
 python-lambda
 pyyaml
 requests

--- a/lambda/sfr-publisher-reader/lib/readers/metReader.py
+++ b/lambda/sfr-publisher-reader/lib/readers/metReader.py
@@ -1,3 +1,4 @@
+from json.decoder import JSONDecodeError
 import os
 import requests
 
@@ -34,9 +35,11 @@ class MetReader(AbsSourceReader):
         for itemID in self.itemIDs:
             logger.info('Fetching metadata for record {}'.format(itemID))
             pageResp = requests.get(self.ITEM_API.format(itemID))
-            pageData = pageResp.json()
-
-            self.works.append(self.scrapeRecordMetadata(itemID, pageData))
+            try:
+                pageData = pageResp.json()
+                self.works.append(self.scrapeRecordMetadata(itemID, pageData))
+            except JSONDecodeError:
+                logger.warning('Unable to fetch metada for record'.format(itemID))
 
     def scrapeRecordMetadata(self, itemID, pageData):
         logger.debug('Extracting data from record {}'.format(itemID))


### PR DESCRIPTION
This implements a few minor fixes for the MET Reader to handle the following error cases:

- Malformed JSON received from the API. These records are simply skipped
- Missing metadata fields in the API response. These errors are caught and the field omitted