### PR TITLE
SFR-906 Add Edition Detail Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 This file documents all updates and releases to the ResearchNow Data Ingest pipeline.
 
+## [0.0.5] - Unreleased
+### Added
+- Edition detail endpoint to the API to allow users to retrieve an individual edition and its component instances
+
 ## [0.0.4] - 2020-04-16
 ### Added
 - New Reader for Internet Archive collections in the sfr-publisher-reader function

--- a/app/sfr-search-api/helpers/apiConstants.js
+++ b/app/sfr-search-api/helpers/apiConstants.js
@@ -1,0 +1,28 @@
+
+/**
+ * Work Table Joins
+ * These relationships are loaded when an API request is received for a work detail
+ * page
+ *
+ * Editions and instances are generally loaded through a separate query to avoid
+ * overly large queries being made
+ *
+ * Possible values are: agents, alt_titles, dates, editions, instances, identifiers,
+ * languages, links, measurements & subjects
+ */
+const workTableJoins = ['measurements', 'subjects', 'agents', 'languages', 'alt_titles']
+
+/**
+ * Instance Table Joins
+ * Relationships to load for instance records, either in an Edition Detail request or
+ * if the "recordType" is set to instance for Work Detail requests
+ *
+ * Possible values are: agents, alt_titles, dates, identifiers, items, languages, links
+ * & measurements
+ */
+const instanceTableJoins = ['agents', 'items', 'languages', 'covers', 'dates', 'rights']
+
+module.exports = {
+  instanceTableJoins,
+  workTableJoins,
+}

--- a/app/sfr-search-api/lib/db.js
+++ b/app/sfr-search-api/lib/db.js
@@ -200,6 +200,7 @@ class DBConnection {
    *
    * @param {array} instanceIds An array of instance row IDs to retrieve
    * @param {integer} limit The maximum number of instances to return
+   * @param {array} joins An array of table names to select subqueries to execute
    *
    * @returns {object} A postgres response object that contains an array of identifiers
    */

--- a/app/sfr-search-api/lib/errors.js
+++ b/app/sfr-search-api/lib/errors.js
@@ -31,8 +31,20 @@ function InvalidFilterError(message) {
 
 InvalidFilterError.prototype = Error.prototype
 
+function NotFoundError(message) {
+  if (!message || typeof message !== 'string' || message.trim() === '') {
+    throw new Error('error message is required')
+  }
+
+  this.message = message
+  this.name = 'NotFoundError'
+}
+
+NotFoundError.prototype = Error.prototype
+
 module.exports = {
   ElasticSearchError,
   MissingParamError,
   InvalidFilterError,
+  NotFoundError,
 }

--- a/app/sfr-search-api/lib/v3Edition.js
+++ b/app/sfr-search-api/lib/v3Edition.js
@@ -1,0 +1,130 @@
+/* eslint-disable prefer-destructuring */
+const Helpers = require('../helpers/esSourceHelpers')
+const { DBConnection } = require('./db')
+
+/** Class representing an edition record. */
+class V3Edition {
+  /**
+   * Create a edition record.
+   *
+   * @param {Object} app Express object, contains various components needed for search.
+   * @param {Integer} editionIdentifier Row id for edition in the postgres database.
+   */
+  constructor(app, editionIdentifier) {
+    this.app = app
+    this.editionID = editionIdentifier
+    this.edition = null
+    this.logger = this.app.logger
+    this.dbConn = new DBConnection(this.logger, app.dbClient)
+  }
+
+  /**
+   * Method to load and format an object containing work metadata from the database
+   *
+   * @param {object} work Parsed work object containing identifiers to be retrieved
+   * @param {*} recordType Inner doc type to be included. Either instances or editions
+   *
+   * @returns {object} Constructed work record that can be sent to the end user
+   */
+  async loadEdition() {
+    const editions = await this.getEditions()
+
+    this.edition = editions[0]
+
+    await this.parseEdition()
+
+    Helpers.parseAgents(this.edition, 'instances')
+    Helpers.parseLinks(this.edition, 'instances')
+    Helpers.parseDates(this.edition, 'instances')
+
+    return this.edition
+  }
+
+  /**
+   * Handler function to retrieve identifiers for a specified row through the
+   * DBConnection class
+   *
+   * @param {string} table Name of the table to retrieve related identifiers. Should
+   * generally be either works or instances (other option is items)
+   * @param {integer} identifier Row ID in the specified table to retrieve identifiers for
+   *
+   * @returns {array} Array of identifier objects with id_type and identifier values
+   */
+  getIdentifiers(table, identifier) {
+    return this.dbConn.loadIdentifiers(table, identifier)
+  }
+
+  /**
+   * Handler function for retrieving a set of editions specified by their internal
+   * postgres row ids through the DBConnection class
+   *
+   * @param {array} editionIds Array of Row IDs to the editions table
+   *
+   * @returns {array} Array of edition objects from the database
+   */
+  getEditions() {
+    return this.dbConn.loadEditions([this.editionID], 1)
+  }
+
+  /**
+   * Handler function for retrieving a set of instances specified by their internal
+   * postgres row ids through the DBConnection class
+   *
+   * @param {array} editionIds Array of Row IDs to the instances table
+   *
+   * @returns {array} Array of instance objects from the database
+   */
+  getInstances() {
+    return this.dbConn.getEditionInstances(this.editionID)
+  }
+
+  async parseEdition() {
+    this.edition.instances = await this.getInstances()
+
+    if (this.edition.publication_date) {
+      this.edition.publication_date = this.edition.publication_date.match(/^\[([0-9]+)/)[1]
+    }
+
+    const titleCounts = this.edition.instances
+      .map(i => i.title)
+      .reduce((titles, title) => {
+        const count = titles[title] || 0
+        // eslint-disable-next-line no-param-reassign
+        titles[title] = count + 1
+        return titles
+      }, {})
+
+    this.edition.title = Object.keys(titleCounts)
+      .sort((a, b) => titleCounts[b] - titleCounts[a])[0]
+
+    this.sortInstances()
+    delete this.edition.items
+    delete this.edition.covers
+  }
+
+  sortInstances() {
+    this.edition.instances.sort((a, b) => {
+      const aHoldings = a.measurements.map(m => m.value)
+      const bHoldings = b.measurements.map(m => m.value)
+      return aHoldings.reduce((acc, cur) => acc + cur) < bHoldings.reduce((acc, cur) => acc + cur)
+    })
+
+    if (this.edition.items) {
+      const editionLinks = this.edition.items.map(i => i.links.map(l => l.url))
+      const featuredInst = this.edition.instances.filter((i) => {
+        if (i.items) {
+          const instanceLinks = i.items.map(t => t.links.map(l => l.url))
+          if (instanceLinks.filter(l => editionLinks.indexOf(l) > -1)) {
+            return i
+          }
+        }
+        return null
+      })
+      const featuredPos = this.edition.instances.indexOf(featuredInst)
+      this.edition.instances.splice(featuredPos, 1)
+      this.edition.instances = [featuredInst, ...this.edition.instances]
+    }
+  }
+}
+
+module.exports = { V3Edition }

--- a/app/sfr-search-api/lib/v3Edition.js
+++ b/app/sfr-search-api/lib/v3Edition.js
@@ -10,10 +10,13 @@ class V3Edition {
    *
    * @param {Object} app Express object, contains various components needed for search.
    * @param {Integer} editionIdentifier Row id for edition in the postgres database.
+   * @param {Boolean} showAll Control display of instances to either all(true) or only
+   * those with items (false).
    */
-  constructor(app, editionIdentifier) {
+  constructor(app, editionIdentifier, showAll) {
     this.app = app
     this.editionID = editionIdentifier
+    this.showAll = showAll
     this.edition = null
     this.logger = this.app.logger
     this.dbConn = new DBConnection(this.logger, app.dbClient)
@@ -91,6 +94,11 @@ class V3Edition {
     // Select the most common instance title as the edition title
     this.edition.title = Object.keys(titleCounts)
       .sort((a, b) => titleCounts[b] - titleCounts[a])[0]
+
+    // If showAll is false, remove instances without items
+    if (this.showAll === 'false') {
+      this.edition.instances = this.edition.instances.filter(i => i.items !== null)
+    }
 
     // Perform a custom sort on the instance array
     this.sortInstances()

--- a/app/sfr-search-api/lib/v3Search.js
+++ b/app/sfr-search-api/lib/v3Search.js
@@ -188,7 +188,7 @@ class V3Search {
    * @returns {array} Array of instance objects from the database
    */
   async getInstances(instanceIds) {
-    return this.dbConn.loadInstances(instanceIds, 1)
+    return this.dbConn.loadInstances(instanceIds, 1, ['agents', 'items', 'languages', 'covers', 'dates', 'rights'])
   }
 
   /**

--- a/app/sfr-search-api/lib/v3Work.js
+++ b/app/sfr-search-api/lib/v3Work.js
@@ -1,4 +1,5 @@
 const Helpers = require('../helpers/esSourceHelpers')
+const { workTableJoins, instanceTableJoins } = require('../helpers/apiConstants')
 const { DBConnection } = require('./db')
 
 /** Class representing a search object. */
@@ -25,7 +26,7 @@ class V3Work {
     let { recordType } = params
     if (!recordType) { recordType = 'editions' }
     const fetchObj = V3Work.getInstanceOrEditions(work)
-    const dbWork = this.loadWork(fetchObj, recordType)
+    const dbWork = this.loadWork(fetchObj, recordType, workTableJoins)
 
     return dbWork
   }
@@ -35,11 +36,12 @@ class V3Work {
    *
    * @param {object} work Parsed work object containing identifiers to be retrieved
    * @param {*} recordType Inner doc type to be included. Either instances or editions
+   * @param {array} joins Array of strings identifying tables to be joined to this query
    *
    * @returns {object} Constructed work record that can be sent to the end user
    */
-  async loadWork(work, recordType) {
-    const dbWork = await this.getWork(work.uuid, ['measurements', 'subjects', 'agents', 'languages', 'alt_titles'])
+  async loadWork(work, recordType, joins) {
+    const dbWork = await this.getWork(work.uuid, joins)
     const identifiers = await this.getIdentifiers('work', dbWork.id)
     dbWork.identifiers = identifiers
     dbWork.instances = null
@@ -105,7 +107,8 @@ class V3Work {
    * @returns {array} Array of instance objects from the database
    */
   getInstances(instanceIds) {
-    return this.dbConn.loadInstances(instanceIds, instanceIds.length, ['agents', 'items', 'languages', 'covers', 'dates', 'rights'])
+    // instanceTableJoins is loaded from the helpers/apiConstants file
+    return this.dbConn.loadInstances(instanceIds, instanceIds.length, instanceTableJoins)
   }
 
   /**

--- a/app/sfr-search-api/lib/v3Work.js
+++ b/app/sfr-search-api/lib/v3Work.js
@@ -105,7 +105,7 @@ class V3Work {
    * @returns {array} Array of instance objects from the database
    */
   getInstances(instanceIds) {
-    return this.dbConn.loadInstances(instanceIds, instanceIds.length)
+    return this.dbConn.loadInstances(instanceIds, instanceIds.length, ['agents', 'items', 'languages', 'covers', 'dates', 'rights'])
   }
 
   /**

--- a/app/sfr-search-api/package.json
+++ b/app/sfr-search-api/package.json
@@ -3,7 +3,7 @@
   "description": "Simple search API to query the SFR Elasticsearch index.",
   "author": "NYPL Digital",
   "license": "MIT",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "dependencies": {
     "@nypl/nypl-data-api-client": "^1.0.0",
     "body-parser": "^1.19.0",

--- a/app/sfr-search-api/routes/v3/edition.js
+++ b/app/sfr-search-api/routes/v3/edition.js
@@ -29,9 +29,13 @@ const fetchEdition = (params, app) => {
     throw new MissingParamError('Your request must include an identifier field or parameter')
   }
 
-  const { editionIdentifier } = params
+  if (params.showAll && params.showAll !== 'true' && params.showAll !== 'false') {
+    throw new MissingParamError('showAll must be set to either "true" or "false"')
+  }
 
-  const v3Edition = new V3Edition(app, editionIdentifier)
+  const { editionIdentifier, showAll } = params
+
+  const v3Edition = new V3Edition(app, editionIdentifier, showAll)
   return v3Edition.loadEdition()
 }
 

--- a/app/sfr-search-api/routes/v3/edition.js
+++ b/app/sfr-search-api/routes/v3/edition.js
@@ -1,0 +1,38 @@
+const { MissingParamError } = require('../../lib/errors')
+const { V3Edition } = require('../../lib/v3Edition')
+
+const editionEndpoints = (app, respond, handleError) => {
+  app.get('/sfr/edition', async (req, res) => {
+    const params = req.query
+
+    try {
+      const editionRes = await fetchEdition(params, app)
+      respond(res, editionRes, params, 'editionRecord')
+    } catch (err) {
+      handleError(res, err)
+    }
+  })
+
+  app.post('/sfr/edition', async (req, res) => {
+    const params = req.body
+    try {
+      const editionRes = await fetchEdition(params, app)
+      respond(res, editionRes, params, 'editionRecord')
+    } catch (err) {
+      handleError(res, err)
+    }
+  })
+}
+
+const fetchEdition = (params, app) => {
+  if (!('editionIdentifier' in params)) {
+    throw new MissingParamError('Your request must include an identifier field or parameter')
+  }
+
+  const { editionIdentifier } = params
+
+  const v3Edition = new V3Edition(app, editionIdentifier)
+  return v3Edition.loadEdition()
+}
+
+module.exports = { fetchEdition, editionEndpoints }

--- a/app/sfr-search-api/routes/v3/v3.js
+++ b/app/sfr-search-api/routes/v3/v3.js
@@ -6,6 +6,7 @@ const logger = require('../../lib/logger')
 const pjson = require('../../package.json')
 const { searchEndpoints } = require('./search')
 const { workEndpoints } = require('./work')
+const { editionEndpoints } = require('./edition')
 const { utilEndpoints } = require('./utils')
 
 // Create an instance of an Express router to handle requests to v2 of the API
@@ -97,5 +98,6 @@ const handleError = (res, error, errType, errReason) => {
 searchEndpoints(v3Router, respond, handleError)
 workEndpoints(v3Router, respond, handleError)
 utilEndpoints(v3Router, respond, handleError)
+editionEndpoints(v3Router, respond, handleError)
 
 module.exports = { v3Router, respond, handleError }

--- a/app/sfr-search-api/swagger.v3.json
+++ b/app/sfr-search-api/swagger.v3.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "v0.3.0",
+    "version": "v0.3.1",
     "title": "ResearchNow Search API",
     "description": "REST API for Elasticsearch index for the ResearchNow Project"
   },
@@ -732,6 +732,106 @@
         }
       }
     },
+    "/v0.1/research-now/v3/edition": {
+      "get": {
+        "tags": [
+          "research-now"
+        ],
+        "summary": "(v3) GET Single edition",
+        "description": "Accepts a single edition identifier, passed through a GET request and retrieves a single edition record. Will raise an error if no or more than one record is returned for the provided identifier",
+        "parameters": [
+          {
+            "name": "editionIdentifier",
+            "in": "query",
+            "description": "Edition identifier, the must be its PostgreSQL row ID, which can be found in the edition object in other API responses.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "An editionRecord response object",
+            "schema": {
+              "$ref": "#/definitions/v3EditionRecord"
+            }
+          },
+          "404": {
+            "description": "Resource was not found error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "422": {
+            "description": "An Invalid Parameter was recieved in the Request",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "default": {
+            "description": "Unexpected Error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "research-now"
+        ],
+        "summary": "(v3) POST Single Edition",
+        "description": "Accepts a single edition identifier, passed through a GET request and retrieves a single edition record. Will raise an error if no or more than one record is returned for the provided identifier",
+        "parameters": [
+          {
+            "name": "editionIdentifier",
+            "in": "body",
+            "description": "Edition identifier, the must be its PostgreSQL row ID, which can be found in the edition object in other API responses.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SingleQuery"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A workRecord response object",
+            "schema": {
+              "$ref": "#/definitions/v3EditionRecord"
+            }
+          },
+          "404": {
+            "description": "Resource was not found error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "422": {
+            "description": "An Invalid Parameter was recieved in the Request",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "default": {
+            "description": "Unexpected Error",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
     "/v0.1/research-now/v3/search-api": {
       "get": {
         "tags": [
@@ -1095,6 +1195,25 @@
         }
       }
     },
+    "v3EditionRecord": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "responseType": {
+          "type": "string"
+        },
+        "data": {
+          "$ref": "#/definitions/v3EditionDetailObject"
+        }
+      }
+    },
     "v3DataObject": {
       "type": "object",
       "properties": {
@@ -1390,6 +1509,71 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/v3ItemObject"
+          }
+        },
+        "languages": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v3LanguageObject"
+          }
+        }
+      }
+    },
+    "v3EditionDetailObject": {
+      "type": "object",
+      "properties": {
+        "date_modified": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "date_created": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "id": {
+          "type": "integer"
+        },
+        "title": {
+          "type": "string"
+        },
+        "publication_place": {
+          "type": "string"
+        },
+        "publication_date": {
+          "type": "string",
+          "format": "date"
+        },
+        "edition": {
+          "type": "string"
+        },
+        "edition_statement": {
+          "type": "string"
+        },
+        "volume": {
+          "type": "string"
+        },
+        "table_of_contents": {
+          "type": "string"
+        },
+        "extent": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "work_id": {
+          "type": "integer"
+        },
+        "agents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v3AgentObject"
+          }
+        },
+        "instances": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v3InstanceObject"
           }
         },
         "languages": {

--- a/app/sfr-search-api/swagger.v3.json
+++ b/app/sfr-search-api/swagger.v3.json
@@ -746,6 +746,12 @@
             "description": "Edition identifier, the must be its PostgreSQL row ID, which can be found in the edition object in other API responses.",
             "required": true,
             "type": "string"
+          }, {
+            "name": "showAll",
+            "in": "query",
+            "description": "Set to control output of instances, if false, this will return only instances with attached items. If true or not set, all instances will be returned",
+            "required": false,
+            "type": "string"
           }
         ],
         "responses": {
@@ -789,12 +795,12 @@
         "description": "Accepts a single edition identifier, passed through a GET request and retrieves a single edition record. Will raise an error if no or more than one record is returned for the provided identifier",
         "parameters": [
           {
-            "name": "editionIdentifier",
+            "name": "editionQuery",
             "in": "body",
-            "description": "Edition identifier, the must be its PostgreSQL row ID, which can be found in the edition object in other API responses.",
+            "description": "Lookup individual edition record detail",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/SingleQuery"
+              "$ref": "#/definitions/SingleEditionQuery"
             }
           }
         ],
@@ -1777,6 +1783,23 @@
           "example": "editions",
           "description": "Either editions or instances to control the type of inner document returned",
           "enum": ["editions", "instances"]
+        }
+      }
+    },
+    "SingleEditionQuery": {
+      "title": "SingleEditionQuery",
+      "type": "object",
+      "properties": {
+        "editionIdentifier": {
+          "type": "integer",
+          "example": "0000000",
+          "description": "Edition identifier, the must be its PostgreSQL row ID, which can be found in the edition object in other API responses."
+        },
+        "showAll": {
+          "type": "string",
+          "example": "false",
+          "description": "Return either all instances or only instances with item records that have readable links",
+          "enum": ["true", "false"]
         }
       }
     },

--- a/app/sfr-search-api/test/swaggerDocs.test.js
+++ b/app/sfr-search-api/test/swaggerDocs.test.js
@@ -24,7 +24,7 @@ describe('Testing Swagger Documentation', () => {
     await req.get('/research-now/swagger-test')
       .expect(200)
       .then((resp) => {
-        expect(resp.text).to.equal('API name: ResearchNow Search API, Version: v0.3.0')
+        expect(resp.text).to.equal('API name: ResearchNow Search API, Version: v0.3.1')
       })
   })
 
@@ -34,7 +34,7 @@ describe('Testing Swagger Documentation', () => {
       .then((resp) => {
         const apiPaths = []
         Object.keys(resp.body.paths).map(path => apiPaths.push(path))
-        expect(apiPaths.length).to.equal(11)
+        expect(apiPaths.length).to.equal(12)
       })
   })
 })

--- a/app/sfr-search-api/test/v3Edition.test.js
+++ b/app/sfr-search-api/test/v3Edition.test.js
@@ -1,0 +1,173 @@
+/* eslint-disable no-undef, no-unused-expressions */
+const chai = require('chai')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+
+chai.should()
+chai.use(sinonChai)
+const { expect } = chai
+
+const Helpers = require('../helpers/esSourceHelpers')
+const { V3Edition } = require('../lib/v3Edition')
+
+describe('v3 edition retrieval tests', () => {
+  describe('loadEdition()', () => {
+    let testEdition
+    let mockGet
+    let mockParse
+    let mockParseAgents
+    let mockParseLinks
+    let mockParseDates
+    beforeEach(() => {
+      testEdition = new V3Edition(sinon.mock(), 1)
+      mockGet = sinon.stub(V3Edition.prototype, 'getEditions')
+      mockParse = sinon.stub(V3Edition.prototype, 'parseEdition')
+      mockParseAgents = sinon.stub(Helpers, 'parseAgents')
+      mockParseLinks = sinon.stub(Helpers, 'parseLinks')
+      mockParseDates = sinon.stub(Helpers, 'parseDates')
+    })
+
+    afterEach(() => {
+      mockGet.restore()
+      mockParse.restore()
+      mockParseAgents.restore()
+      mockParseLinks.restore()
+      mockParseDates.restore()
+    })
+
+    it('should load work from database given edition identifier', async () => {
+      mockGet.returns(['fetchEdition'])
+      const outWork = await testEdition.loadEdition()
+      expect(outWork).to.equal('fetchEdition')
+      expect(mockGet).to.be.calledOnce
+      expect(mockParse).to.be.calledOnce
+      expect(mockParseAgents).to.be.calledOnceWith('fetchEdition', 'instances')
+      expect(mockParseLinks).to.be.calledOnceWith('fetchEdition', 'instances')
+      expect(mockParseDates).to.be.calledOnceWith('fetchEdition', 'instances')
+    })
+
+    it('should raise an error if no matching edition is found', async () => {
+      mockGet.returns([])
+      try {
+        await testEdition.loadEdition()
+      } catch (err) {
+        expect(err.name).to.equal('NotFoundError')
+      }
+      expect(mockParse).to.be.not.calledOnce
+    })
+  })
+
+  describe('getEditions()', () => {
+    let testEdition
+    let mockLoad
+    beforeEach(() => {
+      testEdition = new V3Edition(sinon.mock(), 1)
+      testEdition.dbConn = sinon.mock()
+
+      mockLoad = sinon.mock()
+      testEdition.dbConn.loadEditions = mockLoad
+    })
+
+    it('should return an array of editions', (done) => {
+      mockLoad.returns(['edition1'])
+      const outEditions = testEdition.getEditions()
+      expect(mockLoad).to.be.calledOnceWith([1], 1)
+      expect(outEditions[0]).to.equal('edition1')
+      done()
+    })
+  })
+
+  describe('getInstances()', () => {
+    let testEdition
+    let mockLoad
+    beforeEach(() => {
+      testEdition = new V3Edition(sinon.mock(), 1)
+      testEdition.dbConn = sinon.mock()
+
+      mockLoad = sinon.mock()
+      testEdition.dbConn.getEditionInstances = mockLoad
+    })
+
+    it('should return an array of editions', (done) => {
+      mockLoad.returns(['inst1', 'inst2', 'inst3'])
+      const outInstances = testEdition.getInstances()
+      expect(mockLoad).to.be.calledOnceWith(1)
+      expect(outInstances[1]).to.equal('inst2')
+      done()
+    })
+  })
+
+  describe('parseEdition()', () => {
+    let testEdition
+    let mockSort
+    let mockGetInstances
+    beforeEach(() => {
+      testEdition = new V3Edition(sinon.mock(), 1)
+      testEdition.edition = {}
+      mockSort = sinon.stub(V3Edition.prototype, 'sortInstances')
+      mockGetInstances = sinon.stub(V3Edition.prototype, 'getInstances')
+    })
+
+    afterEach(() => {
+      mockSort.restore()
+      mockGetInstances.restore()
+    })
+
+    it('should select best title by most common among the instances', async () => {
+      mockGetInstances.returns([
+        { title: 'Testing' }, { title: 'Not Testing' }, { title: 'Testing' },
+      ])
+      await testEdition.parseEdition()
+      expect(testEdition.edition.title).to.equal('Testing')
+      expect(mockSort).to.be.calledOnce
+    })
+
+    it('should parse a single year from the publication date range', async () => {
+      mockGetInstances.returns([{ title: 'Testing' }])
+      testEdition.edition.publication_date = '[2000-01-01,2000-12-31)'
+      await testEdition.parseEdition()
+      expect(testEdition.edition.title).to.equal('Testing')
+      expect(testEdition.edition.publication_date).to.equal('2000')
+      expect(mockSort).to.be.calledOnce
+    })
+  })
+
+  describe('sortInstances()', () => {
+    let testEdition
+    beforeEach(() => {
+      testEdition = new V3Edition(sinon.mock(), 1)
+    })
+
+    it('should sort the instances by numbers of holdings', (done) => {
+      testEdition.edition = {
+        instances: [
+          { title: 'inst1', measurements: [{ value: 2 }] },
+          { title: 'inst2', measurements: [{ value: 1 }] },
+          { title: 'inst3', measurements: [{ value: 3 }] },
+        ],
+      }
+
+      testEdition.sortInstances()
+
+      expect(testEdition.edition.instances[0].title).to.equal('inst3')
+      done()
+    })
+
+    it('should sort the instances by numbers of holdings & place featured instance first', (done) => {
+      testEdition.edition = {
+        items: [{ links: [{ url: 'featuredURL' }] }],
+        instances: [
+          { title: 'inst1', measurements: [{ value: 2 }], items: [{ links: [{ url: 'secondaryURL' }] }] },
+          { title: 'inst2', measurements: [{ value: 1 }], items: [{ links: [{ url: 'featuredURL' }] }] },
+          { title: 'inst3', measurements: [{ value: 3 }] },
+        ],
+      }
+
+      testEdition.sortInstances()
+
+      expect(testEdition.edition.instances[0].title).to.equal('inst2')
+      expect(testEdition.edition.instances[1].title).to.equal('inst3')
+      done()
+    })
+  })
+})

--- a/app/sfr-search-api/test/v3Edition.test.js
+++ b/app/sfr-search-api/test/v3Edition.test.js
@@ -130,6 +130,19 @@ describe('v3 edition retrieval tests', () => {
       expect(testEdition.edition.publication_date).to.equal('2000')
       expect(mockSort).to.be.calledOnce
     })
+
+    it('should remove instances without items if showAll is false', async () => {
+      testEdition.showAll = 'false'
+      mockGetInstances.returns([
+        { title: 'Testing', items: 'itemArray' },
+        { title: 'Not Testing', items: null },
+        { title: 'Testing', items: 'itemArray2' },
+      ])
+      await testEdition.parseEdition()
+      expect(testEdition.edition.title).to.equal('Testing')
+      expect(testEdition.edition.instances.length).to.equal(2)
+      expect(mockSort).to.be.calledOnce
+    })
   })
 
   describe('sortInstances()', () => {


### PR DESCRIPTION
Add a new endpoint that accepts an edition row id and returns a response detailing the edition and its component instances. This enables users to see the source data that was "clustered" into the edition.

The response includes metadata from the edition and an array of instances sorted by the number of holdings reported by OCLC, with the first item being a special case in that it is always the instance that contains the links made available through the edition.