### PR TITLE
SFR-910 Add showAll param to work detail endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file documents all updates and releases to the ResearchNow Data Ingest pipe
 ### Added
 - Edition detail endpoint to the API to allow users to retrieve an individual edition and its component instances
 - travisCI deployment for search API
+- Add `showAll` parameter to Work Detail endpoint to restrict return of editions/instances to only those with read online/download options
 
 ## [0.0.4] - 2020-04-16
 ### Added

--- a/app/sfr-search-api/routes/v3/work.js
+++ b/app/sfr-search-api/routes/v3/work.js
@@ -5,7 +5,6 @@ const { V3Work } = require('../../lib/v3Work')
 const workEndpoints = (app, respond, handleError) => {
   app.get('/sfr/work', async (req, res) => {
     const params = req.query
-
     try {
       const workRes = await fetchWork(params, app)
       respond(res, workRes, params, 'workRecord')
@@ -28,6 +27,10 @@ const workEndpoints = (app, respond, handleError) => {
 const fetchWork = (params, app) => {
   if (!('identifier' in params)) {
     throw new MissingParamError('Your request must include an identifier field or parameter')
+  }
+
+  if (params.showAll && params.showAll !== 'true' && params.showAll !== 'false') {
+    throw new MissingParamError('showAll must be set to either "true" or "false"')
   }
 
   // TODO: Implement type-specific identifier matching

--- a/app/sfr-search-api/swagger.v3.json
+++ b/app/sfr-search-api/swagger.v3.json
@@ -634,6 +634,12 @@
             "required": false,
             "type": "string",
             "enum": ["instances", "editions"]
+          },{
+            "name": "showAll",
+            "in": "query",
+            "description": "Set to control output of instances/editions, if false, this will return only instances or editions with attached items. If true or not set, all instances/editions will be returned",
+            "type": "string",
+            "enum": ["true", "false"]
           }
         ],
         "responses": {
@@ -1783,6 +1789,12 @@
           "example": "editions",
           "description": "Either editions or instances to control the type of inner document returned",
           "enum": ["editions", "instances"]
+        },
+        "showAll": {
+            "type": "string",
+            "example": "true",
+            "description": "Set to control output of instances/editions, if false, this will return only instances or editions with attached items. If true or not set, all instances/editions will be returned",
+            "enum": ["true", "false"]
         }
       }
     },

--- a/app/sfr-search-api/test/esIntegrations.test.js
+++ b/app/sfr-search-api/test/esIntegrations.test.js
@@ -441,6 +441,16 @@ describe('Testing ElasticSearch Integration', () => {
         // eslint-disable-next-line no-unused-expressions
         expect(v3Work.isDone()).to.be.true
       })
+
+      it('should return an error if showAll contains an invalid value (not true/false)', async () => {
+        await req.post('/v3/sfr/work')
+          .send({ identifier: 'errTest', showAll: 'random' })
+          .then((resp) => {
+            expect(resp.body.status).to.equal(500)
+            expect(resp.body.name).to.equal('MissingParamError')
+            expect(resp.body.error).to.equal('showAll must be set to either "true" or "false"')
+          })
+      })
     })
 
     describe('v3 Edition Integration', () => {


### PR DESCRIPTION
Adding a `showAll` parameter to control which editions/instances are returned for work detail requests. By default, or if set to `true` this will return all instances/editions. If set to `false` it will only return instances/editions with attached items that can be read online/downloaded. This enables a new setting that are in the UI designs for the detail pages.