### PR TITLE
SFR-909 Add Standard Number Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file documents all updates and releases to the ResearchNow Data Ingest pipe
 ### Added
 - Edition detail endpoint to the API to allow users to retrieve an individual edition and its component instances
 - travisCI deployment for search API
+- Add standardNumber option to search endpoint to query ISBN, ISSN, LCCN and OCLC; either individually or all together. Conforms to other search options
 
 ## [0.0.4] - 2020-04-16
 ### Added

--- a/app/sfr-search-api/lib/v3Search.js
+++ b/app/sfr-search-api/lib/v3Search.js
@@ -524,14 +524,8 @@ class V3Search {
       case 'viaf':
         this.query.query('bool', b => b
           .query('bool', c => c
-            // eslint-disable-next-line arrow-body-style
-            .orQuery('nested', { path: 'agents' }, (q) => {
-              return q.query('term', `agents.${field}`, queryTerm)
-            })
-            // eslint-disable-next-line arrow-body-style
-            .orQuery('nested', { path: 'instances.agents' }, (q) => {
-              return q.query('term', `instances.agents.${field}`, queryTerm)
-            })))
+            .orQuery('nested', { path: 'agents' }, q => q.query('term', `agents.${field}`, queryTerm))
+            .orQuery('nested', { path: 'instances.agents' }, q => q.query('term', `instances.agents.${field}`, queryTerm))))
         break
       case 'subject':
         this.query.query('nested', { path: 'subjects', query: { query_string: { query: queryTerm, default_operator: 'and' } } })

--- a/app/sfr-search-api/lib/v3Search.js
+++ b/app/sfr-search-api/lib/v3Search.js
@@ -539,6 +539,21 @@ class V3Search {
       case 'title':
         this.query.query('query_string', { fields: ['title', 'alt_titles'], query: queryTerm, default_operator: 'and' })
         break
+      case 'isbn':
+      case 'issn':
+      case 'lccn':
+      case 'oclc':
+      case 'standardNumber':
+        // eslint-disable-next-line no-case-declarations
+        const queryFields = (field === 'standardNumber') ? ['isbn', 'issn', 'lccn', 'oclc'] : [field]
+        this.query.query('bool', b => b
+          .orQuery('nested', { path: 'identifiers' }, q => q.query('bool', c => c
+            .andQuery('term', 'identifiers.identifier', queryTerm)
+            .andQuery('terms', 'identifiers.id_type', queryFields)))
+          .orQuery('nested', { path: 'instances.identifiers' }, q => q.query('bool', d => d
+            .andQuery('term', 'instances.identifiers.identifier', queryTerm)
+            .andQuery('terms', 'instances.identifiers.id_type', queryFields))))
+        break
       case 'keyword':
       default:
         this.query.query('bool', b => b

--- a/app/sfr-search-api/package.json
+++ b/app/sfr-search-api/package.json
@@ -3,7 +3,7 @@
   "description": "Simple search API to query the SFR Elasticsearch index.",
   "author": "NYPL Digital",
   "license": "MIT",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "dependencies": {
     "@nypl/nypl-data-api-client": "^1.0.0",
     "body-parser": "^1.19.0",

--- a/app/sfr-search-api/swagger.v3.json
+++ b/app/sfr-search-api/swagger.v3.json
@@ -849,10 +849,10 @@
           {
             "name": "field",
             "in": "query",
-            "description": "Field to query. Currently supports: Keyword, Title, Author and Subject. Defaults to Keyword",
+            "description": "Field to query. Currently supports: Keyword, Title, Author, StandardNumber(ISBN, ISSN, LCCN and OCLC) and Subject. Defaults to Keyword",
             "required": true,
             "type": "string",
-            "enum": ["keyword", "title", "author", "subject", "viaf", "lcnaf"]
+            "enum": ["keyword", "title", "author", "subject", "viaf", "lcnaf", "standardNumber", "isbn", "issn", "lccn", "oclc"]
           },{
             "name": "query",
             "in": "query",
@@ -1808,10 +1808,10 @@
       "type": "object",
       "properties": {
         "field": {
-          "description": "Field to query. Currently supports: Keyword, Title, Author and Subject. Defaults to Keyword",
+          "description": "Field to query. Currently supports: Keyword, Title, Author, StandardNumber(ISBN, ISSN, LCCN and OCLC) and Subject. Defaults to Keyword",
           "type": "string",
           "example": "keyword",
-          "enum": ["keyword", "title", "author", "subject", "viaf", "lcnaf"]
+          "enum": ["keyword", "title", "author", "subject", "viaf", "lcnaf", "standardNumber", "isbn", "issn", "lccn", "oclc"]
         },
         "query": {
           "description": "Query term to search. This is a free-text field and which understands standard boolean search terms as well as quoted strings for exact matching.",

--- a/app/sfr-search-api/swagger.v3.json
+++ b/app/sfr-search-api/swagger.v3.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "v0.3.1",
+    "version": "v0.3.2",
     "title": "ResearchNow Search API",
     "description": "REST API for Elasticsearch index for the ResearchNow Project"
   },

--- a/app/sfr-search-api/test/v3Search.test.js
+++ b/app/sfr-search-api/test/v3Search.test.js
@@ -149,6 +149,29 @@ describe('v3 simple search tests', () => {
       expect(testQuery.query.bool.should[1].nested.query.query_string.query).to.equal('testing')
       done()
     })
+
+    it('should add a nested query for general standardNumber across isbn/issn/lccn/oclc', (done) => {
+      testSearch.buildQuery('standardNumber', 'XXXXXXXXX')
+
+      const testQuery = testSearch.query.build()
+      const boolQuery = testQuery.query.bool
+      expect(boolQuery.should[0].nested.query.bool.must[0].term['identifiers.identifier']).to.equal('XXXXXXXXX')
+      expect(boolQuery.should[0].nested.query.bool.must[1].terms['identifiers.id_type'].length).to.equal(4)
+      expect(boolQuery.should[1].nested.query.bool.must[0].term['instances.identifiers.identifier']).to.equal('XXXXXXXXX')
+      expect(boolQuery.should[1].nested.query.bool.must[1].terms['instances.identifiers.id_type'].length).to.equal(4)
+      done()
+    })
+    it('should add a nested query for a specific standardNumber from isbn/issn/lccn/oclc', (done) => {
+      testSearch.buildQuery('isbn', 'XXXXXXXXX')
+
+      const testQuery = testSearch.query.build()
+      const boolQuery = testQuery.query.bool
+      expect(boolQuery.should[0].nested.query.bool.must[0].term['identifiers.identifier']).to.equal('XXXXXXXXX')
+      expect(boolQuery.should[0].nested.query.bool.must[1].terms['identifiers.id_type'][0]).to.equal('isbn')
+      expect(boolQuery.should[1].nested.query.bool.must[0].term['instances.identifiers.identifier']).to.equal('XXXXXXXXX')
+      expect(boolQuery.should[1].nested.query.bool.must[1].terms['instances.identifiers.id_type'][0]).to.equal('isbn')
+      done()
+    })
   })
 
   it('should query for a simple search field/query pair', async () => {


### PR DESCRIPTION
This adds the option to query Standard Numbers (initially ISBN, ISSN, LCCN and OCLC numbers) through the main `search-api` endpoint. In addition to being able to search these fields specifically, `standardNumber` can also be specified to query across all 4 identifier types.