### PR TITLE
SFR-906 Add identifier array to instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file documents all updates and releases to the ResearchNow Data Ingest pipe
 ## [0.0.5] - Unreleased
 ### Added
 - Edition detail endpoint to the API to allow users to retrieve an individual edition and its component instances
+- Added identifier array to edition detail endpoint
 - travisCI deployment for search API
 - Add standardNumber option to search endpoint to query ISBN, ISSN, LCCN and OCLC; either individually or all together. Conforms to other search options
 - Add `showAll` parameter to Work Detail endpoint to restrict return of editions/instances to only those with read online/download options

--- a/app/sfr-search-api/lib/db.js
+++ b/app/sfr-search-api/lib/db.js
@@ -170,7 +170,7 @@ class DBConnection {
       .groupBy('type')
       .then(async (rows) => {
         const recIds = []
-        rows.forEach(async (row) => {
+        await Promise.all(rows.map(async (row) => {
           const realType = row.type || 'generic'
           const rowIds = await this.pg(realType)
             .whereIn('identifier_id', row.ids)
@@ -186,7 +186,7 @@ class DBConnection {
               return typeIds
             })
           recIds.push(...rowIds)
-        })
+        }))
         return recIds
       })
   }

--- a/app/sfr-search-api/lib/v3Edition.js
+++ b/app/sfr-search-api/lib/v3Edition.js
@@ -69,6 +69,20 @@ class V3Edition {
   }
 
   /**
+   * Handler function to retrieve identifiers for a specified row through the
+   * DBConnection class
+   *
+   * @param {string} table Name of the table to retrieve related identifiers. Should
+   * generally be either works or instances (other option is items)
+   * @param {integer} identifier Row ID in the specified table to retrieve identifiers for
+   *
+   * @returns {array} Array of identifier objects with id_type and identifier values
+   */
+  getIdentifiers(table, identifier) {
+    return this.dbConn.loadIdentifiers(table, identifier)
+  }
+
+  /**
    * Method for performing some basic transformations of source metadata for presentation
    * to end users. This includes parsing dates, selecting the most appropriate title for
    * the edition and sorting the component instances.
@@ -102,6 +116,12 @@ class V3Edition {
 
     // Perform a custom sort on the instance array
     this.sortInstances()
+
+    // Fetch Identifiers for instances
+    await Promise.all(this.edition.instances.map(async (inst) => {
+      // eslint-disable-next-line no-param-reassign
+      inst.identifiers = await this.getIdentifiers('instance', inst.id)
+    }))
 
     // Remove items and covers from the edition; these are displayed on instances
     delete this.edition.items

--- a/app/sfr-search-api/package.json
+++ b/app/sfr-search-api/package.json
@@ -3,7 +3,7 @@
   "description": "Simple search API to query the SFR Elasticsearch index.",
   "author": "NYPL Digital",
   "license": "MIT",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "dependencies": {
     "@nypl/nypl-data-api-client": "^1.0.0",
     "body-parser": "^1.19.0",

--- a/app/sfr-search-api/swagger.v3.json
+++ b/app/sfr-search-api/swagger.v3.json
@@ -1,7 +1,7 @@
 {
   "swagger": "2.0",
   "info": {
-    "version": "v0.3.2",
+    "version": "v0.3.3",
     "title": "ResearchNow Search API",
     "description": "REST API for Elasticsearch index for the ResearchNow Project"
   },
@@ -1666,6 +1666,12 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/v3LanguageObject"
+          }
+        },
+        "identifiers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v3IdentifierObject"
           }
         }
       }

--- a/app/sfr-search-api/test/esIntegrations.test.js
+++ b/app/sfr-search-api/test/esIntegrations.test.js
@@ -478,10 +478,34 @@ describe('Testing ElasticSearch Integration', () => {
             () => {
               expect(query.sql).to.contain('from "instances" where "id"')
               query.response([
-                { title: 'test1', measurements: [{ value: 2 }] },
-                { title: 'test2', measurements: [{ value: 10 }] },
-                { title: 'test3', measurements: [{ value: 5 }] },
+                { id: 1, title: 'test1', measurements: [{ value: 2 }] },
+                { id: 2, title: 'test2', measurements: [{ value: 10 }] },
+                { id: 3, title: 'test3', measurements: [{ value: 5 }] },
               ])
+            },
+            () => {
+              expect(query.sql).to.contain('instance_identifiers')
+              query.response([{ ids: [1, 2], type: 'test' }])
+            },
+            () => {
+              expect(query.sql).to.contain('instance_identifiers')
+              query.response([{ ids: [3, 4], type: 'test' }])
+            },
+            () => {
+              expect(query.sql).to.contain('instance_identifiers')
+              query.response([{ ids: [5, 6], type: 'test' }])
+            },
+            () => {
+              expect(query.sql).to.contain('test')
+              query.response([{ value: 'id1' }, { value: 'id2' }])
+            },
+            () => {
+              expect(query.sql).to.contain('test')
+              query.response([{ value: 'id3' }, { value: 'id4' }])
+            },
+            () => {
+              expect(query.sql).to.contain('test')
+              query.response([{ value: 'id5' }, { value: 'id5' }])
             },
           ][step - 1]()
         })

--- a/app/sfr-search-api/test/swaggerDocs.test.js
+++ b/app/sfr-search-api/test/swaggerDocs.test.js
@@ -24,7 +24,7 @@ describe('Testing Swagger Documentation', () => {
     await req.get('/research-now/swagger-test')
       .expect(200)
       .then((resp) => {
-        expect(resp.text).to.equal('API name: ResearchNow Search API, Version: v0.3.2')
+        expect(resp.text).to.equal('API name: ResearchNow Search API, Version: v0.3.3')
       })
   })
 

--- a/app/sfr-search-api/test/swaggerDocs.test.js
+++ b/app/sfr-search-api/test/swaggerDocs.test.js
@@ -24,7 +24,7 @@ describe('Testing Swagger Documentation', () => {
     await req.get('/research-now/swagger-test')
       .expect(200)
       .then((resp) => {
-        expect(resp.text).to.equal('API name: ResearchNow Search API, Version: v0.3.1')
+        expect(resp.text).to.equal('API name: ResearchNow Search API, Version: v0.3.2')
       })
   })
 

--- a/app/sfr-search-api/test/v3Edition.test.js
+++ b/app/sfr-search-api/test/v3Edition.test.js
@@ -97,20 +97,43 @@ describe('v3 edition retrieval tests', () => {
     })
   })
 
+  describe('getIdentifiers()', () => {
+    let testEdition
+    let mockLoad
+    beforeEach(() => {
+      testEdition = new V3Edition(sinon.mock(), 1)
+      testEdition.dbConn = sinon.mock()
+
+      mockLoad = sinon.mock()
+      testEdition.dbConn.loadIdentifiers = mockLoad
+    })
+
+    it('should return an array of identifiers', (done) => {
+      mockLoad.returns(['id1', 'id2', 'id3'])
+      const outIdentifiers = testEdition.getIdentifiers('instances', 1)
+      expect(mockLoad).to.be.calledOnceWith('instances', 1)
+      expect(outIdentifiers[1]).to.equal('id2')
+      done()
+    })
+  })
+
   describe('parseEdition()', () => {
     let testEdition
     let mockSort
     let mockGetInstances
+    let mockGetIdentifiers
     beforeEach(() => {
       testEdition = new V3Edition(sinon.mock(), 1)
       testEdition.edition = {}
       mockSort = sinon.stub(V3Edition.prototype, 'sortInstances')
       mockGetInstances = sinon.stub(V3Edition.prototype, 'getInstances')
+      mockGetIdentifiers = sinon.stub(V3Edition.prototype, 'getIdentifiers')
     })
 
     afterEach(() => {
       mockSort.restore()
       mockGetInstances.restore()
+      mockGetIdentifiers.restore()
     })
 
     it('should select best title by most common among the instances', async () => {
@@ -120,6 +143,7 @@ describe('v3 edition retrieval tests', () => {
       await testEdition.parseEdition()
       expect(testEdition.edition.title).to.equal('Testing')
       expect(mockSort).to.be.calledOnce
+      expect(mockGetIdentifiers).callCount(3)
     })
 
     it('should parse a single year from the publication date range', async () => {
@@ -129,6 +153,7 @@ describe('v3 edition retrieval tests', () => {
       expect(testEdition.edition.title).to.equal('Testing')
       expect(testEdition.edition.publication_date).to.equal('2000')
       expect(mockSort).to.be.calledOnce
+      expect(mockGetIdentifiers).to.be.calledOnce
     })
 
     it('should remove instances without items if showAll is false', async () => {
@@ -142,6 +167,7 @@ describe('v3 edition retrieval tests', () => {
       expect(testEdition.edition.title).to.equal('Testing')
       expect(testEdition.edition.instances.length).to.equal(2)
       expect(mockSort).to.be.calledOnce
+      expect(mockGetIdentifiers).callCount(2)
     })
   })
 

--- a/app/sfr-search-api/test/v3Edition.test.js
+++ b/app/sfr-search-api/test/v3Edition.test.js
@@ -109,10 +109,15 @@ describe('v3 edition retrieval tests', () => {
     })
 
     it('should return an array of identifiers', (done) => {
-      mockLoad.returns(['id1', 'id2', 'id3'])
+      mockLoad.returns([
+        { identifier: 'id1', id_type: 'test' },
+        { identifier: 'id2', id_type: 'other_test' },
+        { identifier: 'id3', id_type: 'test' },
+      ])
       const outIdentifiers = testEdition.getIdentifiers('instances', 1)
       expect(mockLoad).to.be.calledOnceWith('instances', 1)
-      expect(outIdentifiers[1]).to.equal('id2')
+      expect(outIdentifiers[1].identifier).to.equal('id2')
+      expect(outIdentifiers[1].id_type).to.equal('other_test')
       done()
     })
   })


### PR DESCRIPTION
Identifiers are not included by default in API responses because they increase the size of the response and require an additional database query. For the edition detail they are used to provide access to OCLC records if an OCLC identifier is present