### PR TITLE
SFR-906 Improve Edition Detail Endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This file documents all updates and releases to the ResearchNow Data Ingest pipe
 - travisCI deployment for search API
 - Add standardNumber option to search endpoint to query ISBN, ISSN, LCCN and OCLC; either individually or all together. Conforms to other search options
 - Add `showAll` parameter to Work Detail endpoint to restrict return of editions/instances to only those with read online/download options
+### Fixed
+- Conform edition detail fields to other endpoints
+- Add work UUID to edition detail response
 
 ## [0.0.4] - 2020-04-16
 ### Added

--- a/app/sfr-search-api/lib/db.js
+++ b/app/sfr-search-api/lib/db.js
@@ -397,9 +397,14 @@ class DBConnection {
 
     const sortOrder = `array_position(ARRAY[${editionIds.join(', ')}], id)`
 
+    const workSub = this.pg('works')
+      .where('works.id', this.pg.ref('editions.work_id'))
+      .select('uuid')
+      .as('work_uuid')
+
     return this.pg('editions')
       .whereIn('id', editionIds)
-      .select('*', langSub, agentSub, itemSub, coverSub)
+      .select('*', langSub, agentSub, itemSub, coverSub, workSub)
       .orderBy(this.pg.raw(sortOrder))
       .limit(limit)
       .then(rows => rows)

--- a/app/sfr-search-api/lib/v3Edition.js
+++ b/app/sfr-search-api/lib/v3Edition.js
@@ -123,6 +123,12 @@ class V3Edition {
       inst.identifiers = await this.getIdentifiers('instance', inst.id)
     }))
 
+    // Rename pub_place field in instances for consistency
+    this.edition.instances.forEach((inst) => {
+      // eslint-disable-next-line no-param-reassign
+      inst.publication_place = inst.pub_place; delete inst.pub_place
+    })
+
     // Remove items and covers from the edition; these are displayed on instances
     delete this.edition.items
     delete this.edition.covers

--- a/app/sfr-search-api/test/esIntegrations.test.js
+++ b/app/sfr-search-api/test/esIntegrations.test.js
@@ -466,6 +466,7 @@ describe('Testing ElasticSearch Integration', () => {
           [
             () => {
               expect(query.sql).to.contain('from "editions" where "id"')
+              expect(query.sql).to.contain('work_uuid')
               query.response([{
                 id: 1,
                 summary: 'Test Summary',

--- a/app/sfr-search-api/test/v3Edition.test.js
+++ b/app/sfr-search-api/test/v3Edition.test.js
@@ -174,6 +174,13 @@ describe('v3 edition retrieval tests', () => {
       expect(mockSort).to.be.calledOnce
       expect(mockGetIdentifiers).callCount(2)
     })
+
+    it('should replace pub_place with publication_place in instances', async () => {
+      mockGetInstances.returns([{ title: 'Testing', items: null, pub_place: 'Test Place' }])
+      await testEdition.parseEdition()
+      expect(testEdition.edition.instances[0].publication_place).to.equal('Test Place')
+      expect(testEdition.edition.instances[0].pub_place).to.be.undefined
+    })
   })
 
   describe('sortInstances()', () => {


### PR DESCRIPTION
This makes a few improvements to the edition detail API response:

1) Adds the work UUID to the response object to allow for navigation back to the work
2) Renames the pub_place field on instances to publication_place to keep this consistent with the edition record