### PR TITLE
SFR-882 Fix OCLC 856 field parser for IA books

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file documents all updates and releases to the ResearchNow Data Ingest pipe
 ### Fixed
 - Conform edition detail fields to other endpoints
 - Add work UUID to edition detail response
+- `856` field parser for OCLC Catalog lookup to properly assess readability of IA links
 
 ## [0.0.4] - 2020-04-16
 ### Added

--- a/lambda/sfr-oclc-lookup/lib/parsers/parse856Holding.py
+++ b/lambda/sfr-oclc-lookup/lib/parsers/parse856Holding.py
@@ -74,7 +74,7 @@ class HoldingParser:
 
                 # Check if link is accessible (e.g. public domain/open source)
                 if source == 'internetarchive':
-                    if self.checkIAStatus() is True:
+                    if self.checkIAReadability() is True:
                         return None
                     linkID = Identifier(
                         identifier='ia.{}'.format(self.identifier),
@@ -113,13 +113,14 @@ class HoldingParser:
                 })
                 return True
 
-    def checkIAStatus(self):
+    def checkIAReadability(self):
         metadataURI = self.uri.replace('details', 'metadata')
         metadataResp = requests.get(metadataURI)
         if metadataResp.status_code == 200:
             iaData = metadataResp.json()
-            iaMeta = iaData['metadata']
-            if iaMeta.get('access-restricted-item', False) is False:
+            iaAccessStatus = iaData['metadata'].get('access-restricted-item', False)
+            iaAccessBool = False if iaAccessStatus == 'false' else True
+            if iaAccessBool is False:
                 return False
         
         return True

--- a/lambda/sfr-oclc-lookup/tests/test_holdingParser.py
+++ b/lambda/sfr-oclc-lookup/tests/test_holdingParser.py
@@ -98,31 +98,31 @@ class TestHoldingParse(unittest.TestCase):
         self.assertEqual(testInst.instance.links[0], 'testLink')
 
     @patch.multiple(
-        HoldingParser, checkIAStatus=DEFAULT, parseHathiLink=DEFAULT
+        HoldingParser, checkIAReadability=DEFAULT, parseHathiLink=DEFAULT
     )
-    def test_matchEbook_generic(self, checkIAStatus, parseHathiLink):
+    def test_matchEbook_generic(self, checkIAReadability, parseHathiLink):
         mockInstance = MagicMock()
         testInst = HoldingParser('856Field', mockInstance)
         testInst.uri = 'www.test.org/test123.epub'
         testInst.matchEbook()
-        checkIAStatus.assert_not_called()
+        checkIAReadability.assert_not_called()
         parseHathiLink.assert_not_called()
         mockInstance.addFormat.assert_not_called()
 
     @patch.multiple(
-        HoldingParser, checkIAStatus=DEFAULT, parseHathiLink=DEFAULT
+        HoldingParser, checkIAReadability=DEFAULT, parseHathiLink=DEFAULT
     )
-    def test_matchEbook_gutenberg(self, checkIAStatus, parseHathiLink):
+    def test_matchEbook_gutenberg(self, checkIAReadability, parseHathiLink):
         mockInstance = MagicMock()
         testInst = HoldingParser('856Field', mockInstance)
         testInst.uri = 'gutenberg.org/ebooks/123.epub.images'
         testInst.identifier = 1
         testInst.matchEbook()
-        checkIAStatus.assert_not_called()
+        checkIAReadability.assert_not_called()
         parseHathiLink.assert_not_called()
         mockInstance.addFormat.assert_called_once()
     
-    @patch.object(HoldingParser, 'checkIAStatus')
+    @patch.object(HoldingParser, 'checkIAReadability')
     def test_matchEBook_ia_success(self, mockIACheck):
         mockIACheck.return_value = True
         testInst = HoldingParser('856Field', 'mockInstance')
@@ -148,7 +148,7 @@ class TestHoldingParse(unittest.TestCase):
         )
 
     @patch('lib.parsers.parse856Holding.requests')
-    def test_checkIAStatus_not_restricted(self, mockReq):
+    def test_checkIAReadability_not_restricted(self, mockReq):
         testInst = HoldingParser('mock856', 'mockInstance')
         testInst.uri = 'archive.org/detail/testwork00'
 
@@ -156,14 +156,14 @@ class TestHoldingParse(unittest.TestCase):
         mockResp.status_code = 200
         mockResp.json.return_value = {
             'metadata': {
-                'access-restricted-item': False
+                'access-restricted-item': 'false'
             }
         }
         mockReq.get.return_value = mockResp
-        self.assertFalse(testInst.checkIAStatus())
+        self.assertFalse(testInst.checkIAReadability())
 
     @patch('lib.parsers.parse856Holding.requests')
-    def test_checkIAStatus_restricted(self, mockReq):
+    def test_checkIAReadability_restricted(self, mockReq):
         testInst = HoldingParser('mock856', 'mockInstance')
         testInst.uri = 'archive.org/detail/testwork00'
 
@@ -171,11 +171,11 @@ class TestHoldingParse(unittest.TestCase):
         mockResp.status_code = 200
         mockResp.json.return_value = {
             'metadata': {
-                'access-restricted-item': True
+                'access-restricted-item': 'true'
             }
         }
         mockReq.get.return_value = mockResp
-        self.assertTrue(testInst.checkIAStatus())
+        self.assertTrue(testInst.checkIAReadability())
 
     @patch.object(HoldingParser, 'loadCatalogLinks')
     def test_parseHathiLink(self, mockLoad):


### PR DESCRIPTION
This parser was incorrectly treating the accessibilty field in the InternetArchive metadata response as a boolean value when it was a string true/false field.

This updates that method to take this into account and updates the relevant tests to be sure that they reflect the real-world use case. The method has also been renamed to make its function clearer.