### PR TITLE
NOREF Add sub_title to edition detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This file documents all updates and releases to the ResearchNow Data Ingest pipe
 ### Fixed
 - Conform edition detail fields to other endpoints
 - Add work UUID to edition detail response
+- Add `sub_title` to edition detail response block
 
 ## [0.0.4] - 2020-04-16
 ### Added

--- a/app/sfr-search-api/lib/v3Edition.js
+++ b/app/sfr-search-api/lib/v3Edition.js
@@ -99,15 +99,19 @@ class V3Edition {
     const titleCounts = this.edition.instances
       .map(i => i.title)
       .reduce((titles, title) => {
-        const count = titles[title] || 0
         // eslint-disable-next-line no-param-reassign
-        titles[title] = count + 1
+        titles[title] = (titles[title] || 0) + 1
         return titles
       }, {})
 
     // Select the most common instance title as the edition title
     this.edition.title = Object.keys(titleCounts)
       .sort((a, b) => titleCounts[b] - titleCounts[a])[0]
+
+    // Assign sub_title from instance that title was drawn from
+    const titleInsts = this.edition.instances
+      .filter(i => i.title === this.edition.title && i.sub_title)
+    this.edition.sub_title = titleInsts.length > 0 ? titleInsts[0].sub_title : null
 
     // If showAll is false, remove instances without items
     if (this.showAll === 'false') {

--- a/app/sfr-search-api/swagger.v3.json
+++ b/app/sfr-search-api/swagger.v3.json
@@ -1550,7 +1550,7 @@
         },
         "sub_title": {
           "type": "string"
-        }
+        },
         "publication_place": {
           "type": "string"
         },

--- a/app/sfr-search-api/swagger.v3.json
+++ b/app/sfr-search-api/swagger.v3.json
@@ -1548,6 +1548,9 @@
         "title": {
           "type": "string"
         },
+        "sub_title": {
+          "type": "string"
+        }
         "publication_place": {
           "type": "string"
         },

--- a/app/sfr-search-api/test/v3Edition.test.js
+++ b/app/sfr-search-api/test/v3Edition.test.js
@@ -149,6 +149,7 @@ describe('v3 edition retrieval tests', () => {
       ])
       await testEdition.parseEdition()
       expect(testEdition.edition.title).to.equal('Testing')
+      expect(testEdition.edition.sub_title).to.equal('Testing Sub')
       expect(mockSort).to.be.calledOnce
       expect(mockGetIdentifiers).callCount(3)
     })

--- a/app/sfr-search-api/test/v3Edition.test.js
+++ b/app/sfr-search-api/test/v3Edition.test.js
@@ -143,7 +143,9 @@ describe('v3 edition retrieval tests', () => {
 
     it('should select best title by most common among the instances', async () => {
       mockGetInstances.returns([
-        { title: 'Testing' }, { title: 'Not Testing' }, { title: 'Testing' },
+        { title: 'Testing', sub_title: 'Testing Sub' },
+        { title: 'Not Testing', sub_title: 'Other Sub' },
+        { title: 'Testing', sub_title: '' },
       ])
       await testEdition.parseEdition()
       expect(testEdition.edition.title).to.equal('Testing')


### PR DESCRIPTION
This includes the `sub_title` field from instances in the edition response block. The field is drawn from an instance with the same title as the one set for the edition, and provides a slightly better look at the metadata for each record