### PR TITLE
SFR-858 Add Government Document Filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file documents all updates and releases to the ResearchNow Data Ingest pipe
 - travisCI deployment for search API
 - Add standardNumber option to search endpoint to query ISBN, ISSN, LCCN and OCLC; either individually or all together. Conforms to other search options
 - Add `showAll` parameter to Work Detail endpoint to restrict return of editions/instances to only those with read online/download options
+- `government_document` filter to select only documents that have the government document tag
 ### Fixed
 - Conform edition detail fields to other endpoints
 - Add work UUID to edition detail response

--- a/app/sfr-search-api/lib/v3Search.js
+++ b/app/sfr-search-api/lib/v3Search.js
@@ -735,6 +735,10 @@ class V3Search {
             }
             this.formats.push(formatFilterTrans[value])
             break
+          case 'government_document':
+            this.logger.debug(`Filtering works for goverment document status ${value}`)
+            this.query.query('term', 'is_government_document', value)
+            break
           default:
             this.logger.error('API Not configured to handle this filter')
             throw new InvalidFilterError(`${field} is not a valid filter option`)

--- a/app/sfr-search-api/package.json
+++ b/app/sfr-search-api/package.json
@@ -3,7 +3,7 @@
   "description": "Simple search API to query the SFR Elasticsearch index.",
   "author": "NYPL Digital",
   "license": "MIT",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "dependencies": {
     "@nypl/nypl-data-api-client": "^1.0.0",
     "body-parser": "^1.19.0",

--- a/app/sfr-search-api/swagger.v3.json
+++ b/app/sfr-search-api/swagger.v3.json
@@ -1950,7 +1950,7 @@
       "properties": {
         "field": {
           "type": "string",
-          "enum": ["language", "years", "show_all", "format"],
+          "enum": ["language", "years", "show_all", "format", "government_document"],
           "description": "Field on which to match results by (effectively exact-match search)"
         },
         "value": {

--- a/app/sfr-search-api/test/v3Search.test.js
+++ b/app/sfr-search-api/test/v3Search.test.js
@@ -259,9 +259,13 @@ describe('v3 simple search tests', () => {
   })
 
   describe('addFilters()', () => {
-    it('should add gte/lte date filter on publication dates', (done) => {
-      const testApp = sinon.mock()
+    let testApp
+    beforeEach(() => {
+      testApp = sinon.mock()
       testApp.logger = logger
+    })
+
+    it('should add gte/lte date filter on publication dates', (done) => {
       const testParams = { filters: [{ field: 'years', value: { start: 1900, end: 2000 } }] }
       const testSearch = new V3Search(testApp, testParams)
       testSearch.query = bodybuilder()
@@ -274,8 +278,6 @@ describe('v3 simple search tests', () => {
     })
 
     it('should add gte date filter on publication dates if only start is provided', (done) => {
-      const testApp = sinon.mock()
-      testApp.logger = logger
       const testParams = { filters: [{ field: 'years', value: { start: 1900 } }] }
       const testSearch = new V3Search(testApp, testParams)
       testSearch.query = bodybuilder()
@@ -289,8 +291,6 @@ describe('v3 simple search tests', () => {
     })
 
     it('should add multiple language filters in a bool query block', (done) => {
-      const testApp = sinon.mock()
-      testApp.logger = logger
       const testParams = { filters: [{ field: 'language', value: 'Testing' }, { field: 'language', value: 'Hello' }] }
       const testSearch = new V3Search(testApp, testParams)
       testSearch.query = bodybuilder()
@@ -303,8 +303,6 @@ describe('v3 simple search tests', () => {
     })
 
     it('should add the show_all filter unless specific disabled', (done) => {
-      const testApp = sinon.mock()
-      testApp.logger = logger
       const testParams = {}
       const testSearch = new V3Search(testApp, testParams)
       testSearch.query = bodybuilder()
@@ -316,8 +314,6 @@ describe('v3 simple search tests', () => {
     })
 
     it('should not include the show_all filter if disabled', (done) => {
-      const testApp = sinon.mock()
-      testApp.logger = logger
       const testParams = { filters: [{ field: 'show_all', value: true }] }
       const testSearch = new V3Search(testApp, testParams)
       testSearch.query = bodybuilder()
@@ -328,8 +324,6 @@ describe('v3 simple search tests', () => {
     })
 
     it('should create an array of format filter options', (done) => {
-      const testApp = sinon.mock()
-      testApp.logger = logger
       const testParams = { filters: [{ field: 'format', value: 'pdf' }, { field: 'format', value: 'epub' }] }
       const testSearch = new V3Search(testApp, testParams)
       testSearch.query = bodybuilder()
@@ -340,9 +334,17 @@ describe('v3 simple search tests', () => {
       done()
     })
 
+    it('should add the government_document filter if provided', (done) => {
+      const testParams = { filters: [{ field: 'government_document', value: true }] }
+      const testSearch = new V3Search(testApp, testParams)
+      testSearch.query = bodybuilder()
+      testSearch.addFilters()
+      testBody = testSearch.query.build()
+      expect(testBody.query.bool.must[0].term.is_government_document).to.equal(true)
+      done()
+    })
+
     it('should throw an InvalidFilterError if format is not recognized', (done) => {
-      const testApp = sinon.mock()
-      testApp.logger = logger
       const testParams = { filters: [{ field: 'format', value: 'pbf' }, { field: 'format', value: 'epub' }] }
       const testSearch = new V3Search(testApp, testParams)
       testSearch.query = bodybuilder()

--- a/lambda/sfr-clstr-manager/lib/esManager.py
+++ b/lambda/sfr-clstr-manager/lib/esManager.py
@@ -136,6 +136,10 @@ class ElasticManager():
             ElasticManager.addLanguage(lang)
             for lang in self.dbWork.language
         }
+        
+        self.work.is_government_document = ElasticManager.addGovDocStatus(
+            self.dbWork.measurements
+        )
 
         self.work.instances = []
         self.addInstances()
@@ -202,6 +206,17 @@ class ElasticManager():
             logger.debug('Adding new agent {}'.format(agent))
             return esAgent
     
+    @staticmethod
+    def addGovDocStatus(measurements):
+        govDocMeasurement = list(filter(
+            lambda x: x.quantity == 'government_document', measurements
+        ))
+        if len(govDocMeasurement) > 0:
+            if int(govDocMeasurement[0].value) == 1:
+                return True
+        
+        return False
+
     def addInstances(self):
         for instance in self.dbWork.instances:
             self.work.instances.append(self.addInstance(instance))

--- a/lambda/sfr-clstr-manager/model/elasticModel.py
+++ b/lambda/sfr-clstr-manager/model/elasticModel.py
@@ -192,6 +192,7 @@ class Work(BaseDoc):
     alt_titles = Text(fields={'keyword': Keyword()})
     issued_date = DateRange(format='date_optional_time')
     created_date = DateRange(format='date_optional_time')
+    is_government_document = Boolean(multi=False)
 
     instances = Nested(Instance)
     identifiers = Nested(Identifier)

--- a/lambda/sfr-clstr-manager/tests/test_esManager.py
+++ b/lambda/sfr-clstr-manager/tests/test_esManager.py
@@ -99,10 +99,12 @@ class TestElasticManager(object):
             addIdentifier=DEFAULT,
             addLanguage=DEFAULT,
             addInstances=DEFAULT,
+            addGovDocStatus=DEFAULT,
             _loadDates=mockDateLoader
         ) as esMocks:
             testManager.enhanceWork()
             esMocks['addInstances'].assert_called_once()
+            esMocks['addGovDocStatus'].assert_called_once()
         
         assert testManager.work.issued_date == '1999'
         assert testManager.work.created_date == '2000'
@@ -233,3 +235,26 @@ class TestElasticManager(object):
             assert newInstance.title == 'Test Instance'
             assert newInstance.instance_id == 1
             assert newInstance.pub_date_sort == '2000-01-01'
+    
+    def test_addGovDocStatus_true(self, testManager):
+        testManager.dbWork.measurements = [
+            MagicMock(quantity='count', value=10),
+            MagicMock(quantity='government_document', value=1),
+            MagicMock(quantity='holdings', value=0)
+        ]
+        assert ElasticManager.addGovDocStatus(testManager.dbWork.measurements) == True
+    
+    def test_addGovDocStatus_false(self, testManager):
+        testManager.dbWork.measurements = [
+            MagicMock(quantity='count', value=10),
+            MagicMock(quantity='government_document', value=0),
+            MagicMock(quantity='holdings', value=0)
+        ]
+        assert ElasticManager.addGovDocStatus(testManager.dbWork.measurements) == False
+    
+    def test_addGovDocStatus_not_present(self, testManager):
+        testManager.dbWork.measurements = [
+            MagicMock(quantity='count', value=10),
+            MagicMock(quantity='holdings', value=0)
+        ]
+        assert ElasticManager.addGovDocStatus(testManager.dbWork.measurements) == False


### PR DESCRIPTION
This implements a filter on a new ElasticSearch document field `is_government_document`. This is a simple filter implemented in the API and can be included in the front end as a checkbox.

This also adds the field to the ES model in the clustering function, which will ensure that the field is populated for all newly indexed documents.