### PR TITLE
SFR-939 SCC Integration fixes

### DIFF
--- a/app/sfr-search-api/lib/v3Search.js
+++ b/app/sfr-search-api/lib/v3Search.js
@@ -715,7 +715,16 @@ class V3Search {
             break
           case 'language':
             this.logger.debug(`Filtering works by language ${value}`)
-            langFilters.push(['nested', { path: 'instances.languages', query: { term: { 'instances.languages.language': value } } }])
+            // eslint-disable-next-line no-case-declarations
+            const langBoolQuery = {
+              bool: {
+                should: [
+                  { term: { 'instances.languages.language': value } },
+                  { term: { 'instances.languages.iso_3': value.toLowerCase() } },
+                ],
+              },
+            }
+            langFilters.push(['nested', { path: 'instances.languages', query: langBoolQuery }])
             break
           case 'show_all':
             if (!(typeof value === 'boolean')) {

--- a/app/sfr-search-api/routes/v3/search.js
+++ b/app/sfr-search-api/routes/v3/search.js
@@ -34,7 +34,16 @@ const searchEndpoints = (app, respond, handleError) => {
   })
 
   app.get('/sfr/search', async (rec, res) => {
-    const params = rec.query
+    const params = {}
+
+    // Handle any JSON parts of the query
+    Object.keys(rec.query).forEach((key) => {
+      try {
+        params[key] = JSON.parse(rec.query[key])
+      } catch (err) {
+        params[key] = rec.query[key] // Not a JSON field, just add value to params
+      }
+    })
 
     const searcher = new V3Search(app, params)
 

--- a/app/sfr-search-api/test/v3Search.test.js
+++ b/app/sfr-search-api/test/v3Search.test.js
@@ -312,14 +312,14 @@ describe('v3 simple search tests', () => {
     })
 
     it('should add multiple language filters in a bool query block', (done) => {
-      const testParams = { filters: [{ field: 'language', value: 'Testing' }, { field: 'language', value: 'Hello' }] }
+      const testParams = { filters: [{ field: 'language', value: 'Testing' }, { field: 'language', value: 'tes' }] }
       const testSearch = new V3Search(testApp, testParams)
       testSearch.query = bodybuilder()
       testSearch.addFilters()
       testBody = testSearch.query.build()
       expect(testBody).to.have.property('query')
-      expect(testBody.query.bool.must[0].nested.query.bool.must[1].nested.query.term['instances.languages.language']).to.equal('Testing')
-      expect(testBody.query.bool.must[1].nested.query.bool.must[1].nested.query.term['instances.languages.language']).to.equal('Hello')
+      expect(testBody.query.bool.must[0].nested.query.bool.must[1].nested.query.bool.should[0].term['instances.languages.language']).to.equal('Testing')
+      expect(testBody.query.bool.must[1].nested.query.bool.must[1].nested.query.bool.should[1].term['instances.languages.iso_3']).to.equal('tes')
       done()
     })
 


### PR DESCRIPTION
This PR implements a few minor updates and fixes in the DRB API to support the integration work being done with SCC. Specifically these changes are:

- Fixing the search GET endpoint, which was not properly parsing complex parameter values. These simply needed to be parsed as JSON to extract the correct objects. This will now work in an identical manner to the POST method.
- The DRB API previously only supported filtering by languages by the full name of each language. SCC uses ISO_3 language codes to provide this functionality. To improve this integration, this adds that as a default option to the API, so that the language filter will accept either type of language.

Finally, a question was raised about differences in results between the API under test and the production site. They use different indexes and datasets, which explains the discrepancy. To see what is in the development data the dev site at http://sfr-front-end-development.us-east-1.elasticbeanstalk.com/ can be used