### PR TITLE
SFR-931 Remove Download links from Google-digitized books

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file documents all updates and releases to the ResearchNow Data Ingest pipe
 ### Fixed
 - GET method for the search endpoint when using sort and filter options
 - Handle database errors in a more logical and clear way
+- Omit download links for HathiTrust works digitized by Google
 
 ## [0.0.5] - 2020-06-05
 ### Added

--- a/lambda/sfr-hathi-reader/lib/hathiRecord.py
+++ b/lambda/sfr-hathi-reader/lib/hathiRecord.py
@@ -594,16 +594,17 @@ class HathiRecord():
         })
 
         # The link to the direct PDF download
-        self.item.addClassItem('links', Link, **{
-            'url': 'https://babel.hathitrust.org/cgi/imgsrv/download/pdf?id={}'.format(self.ingest['htid']),
-            'media_type': 'application/pdf',
-            'flags': {
-                'local': False,
-                'download': True,
-                'images': True,
-                'ebook': True
-            }
-        })
+        if self.ingest['digitization_entity'].lower() != 'google':
+            self.item.addClassItem('links', Link, **{
+                'url': 'https://babel.hathitrust.org/cgi/imgsrv/download/pdf?id={}'.format(self.ingest['htid']),
+                'media_type': 'application/pdf',
+                'flags': {
+                    'local': False,
+                    'download': True,
+                    'images': True,
+                    'ebook': True
+                }
+            })
 
         logger.debug('Storing repository {} as agent'.format(
             self.ingest['provider_entity']

--- a/lambda/sfr-hathi-reader/tests/test_hathiRecord.py
+++ b/lambda/sfr-hathi-reader/tests/test_hathiRecord.py
@@ -163,6 +163,21 @@ class TestHathi(unittest.TestCase):
         itemTest.buildItem()
         self.assertIsInstance(itemTest.item, Format)
         self.assertEqual(itemTest.item.source, 'hathitrust')
+        self.assertEqual(len(itemTest.item.links), 2)
+
+    def test_build_item_google_digitization(self):
+        testItemRow = {
+            'htid': 'test.00000',
+            'provider_entity': 'nypl',
+            'responsible_entity': 'nypl',
+            'digitization_entity': 'google',
+        }
+        itemTest = HathiRecord(testItemRow)
+        itemTest.buildItem()
+        self.assertIsInstance(itemTest.item, Format)
+        self.assertEqual(itemTest.item.source, 'hathitrust')
+        self.assertEqual(len(itemTest.item.links), 1)
+        self.assertEqual(itemTest.item.links[0].flags['download'], False)
 
     def test_create_rights(self):
         testRightsRow = {


### PR DESCRIPTION
The download option for Google digitized does not work offsite for NYPL because we cannot provide a partner login to HathiTrust. This may be possible in the future, but for the time being we need to remove these links. This simply prevents the download link from being generated for Google-digitized items.