### PR TITLE
HOTFIX Handle alternate ISO 639-2 language codes

### DIFF
--- a/app/sfr-search-api/lib/v3Search.js
+++ b/app/sfr-search-api/lib/v3Search.js
@@ -22,6 +22,29 @@ const formatFilterTrans = {
   html: 'text/html',
 }
 
+const alt639LanguageCodes = {
+  alb: 'sqi',
+  arm: 'hye',
+  baq: 'eus',
+  bur: 'mya',
+  cze: 'ces',
+  chi: 'zho',
+  ger: 'deu',
+  dut: 'nld',
+  gre: 'ell',
+  fre: 'fra',
+  geo: 'kat',
+  ice: 'isl',
+  mac: 'mkd',
+  mao: 'mri',
+  may: 'msa',
+  per: 'fas',
+  rum: 'ron',
+  slo: 'slk',
+  tib: 'bod',
+  wel: 'cym',
+}
+
 /**
  * Class representing a v3 API search object. This replicates the functionality of
  * the v2 search endpoint but connects to the postgres database for loading metadata
@@ -730,17 +753,19 @@ class V3Search {
             break
           case 'language':
             this.logger.debug(`Filtering works by language ${value}`)
-            // eslint-disable-next-line no-case-declarations
+            /* eslint-disable no-case-declarations */
+            const filterLang = alt639LanguageCodes[value.toLowerCase()] || value
             const langBoolQuery = {
               bool: {
                 should: [
-                  { term: { 'instances.languages.language': value } },
-                  { term: { 'instances.languages.iso_3': value.toLowerCase() } },
+                  { term: { 'instances.languages.language': filterLang } },
+                  { term: { 'instances.languages.iso_3': filterLang.toLowerCase() } },
                 ],
               },
             }
             langFilters.push(['nested', { path: 'instances.languages', query: langBoolQuery }])
             break
+            /* eslint-enable no-case-declarations */
           case 'show_all':
             if (!(typeof value === 'boolean')) {
               throw new InvalidFilterError('The show_all filter only accepts boolean values')

--- a/app/sfr-search-api/test/v3Search.test.js
+++ b/app/sfr-search-api/test/v3Search.test.js
@@ -323,6 +323,17 @@ describe('v3 simple search tests', () => {
       done()
     })
 
+    it('should replace a alternate ISO 639-2 code with standard code', (done) => {
+      const testParams = { filters: [{ field: 'language', value: 'ger' }] }
+      const testSearch = new V3Search(testApp, testParams)
+      testSearch.query = bodybuilder()
+      testSearch.addFilters()
+      testBody = testSearch.query.build()
+      expect(testBody).to.have.property('query')
+      expect(testBody.query.nested.query.bool.must[1].nested.query.bool.should[1].term['instances.languages.iso_3']).to.equal('deu')
+      done()
+    })
+
     it('should add the show_all filter unless specific disabled', (done) => {
       const testParams = {}
       const testSearch = new V3Search(testApp, testParams)


### PR DESCRIPTION
Old metadata records can contain deprecated ISO 639-2 language codes (called "bibliographic" codes in some cases) and the SFR API should handle these accurately. Since there are only a small number (20) this is handled easily with a small object and basic lookup to make replace any instances found. This allows us to keep the normalized language data in our database and hopefully provide a better search/filter experience without compromising on accuracy.